### PR TITLE
Fix text contrast in header

### DIFF
--- a/_data/address.yml
+++ b/_data/address.yml
@@ -1,3 +1,4 @@
+name: Paradise Cove Lodge
 streetAddress: 10700 Highway 178
 addressLocality: Lake Isabella
 addressRegion: CA
@@ -5,3 +6,6 @@ postalCode: 93240
 addressCountry: USA
 telephone: "+1-760-379-2719"
 url: "https://goo.gl/maps/HVrsM1jr7cbRykck9"
+geo:
+  latitude: 35.648349
+  longitude: -118.427896

--- a/_includes/map.html
+++ b/_includes/map.html
@@ -1,0 +1,13 @@
+<leaflet-map center="{{ include.address.geo.latitude }},{{ include.address.geo.longitude }}" zoom="13" minzoom="13" maxzoom="15" crossorigin="annonymous" zoomcontrol="" detectretina="" aria-hidden="true">
+	<leaflet-marker latitude="{{ include.address.geo.latitude }}" longitude="{{ include.address.geo.longitude }}" open="">
+		{% if include.address.url %}
+			<a href="{{ include.address.url }}" rel="noopener external" slot="popup">
+				{% include icon.html icon="link-external" height="16" width="16" %}
+				<span>{{ include.address.name }}</span>
+			</a>
+		{% else %}
+			<div slot="popup">{{ include.address.name }}</div>
+		{% endif %}
+		<img slot="icon" src="/img/adwaita-icons/actions/mark-location.svg" width="32" height="32" decoding="async" loading="lazy" />
+	</leaflet-marker>
+</leaflet-map>

--- a/about.md
+++ b/about.md
@@ -25,9 +25,4 @@ All of our rooms  share a community front porch and have great lake views.
 There is a community lounge area.  The rooms have new flat screen TV's with
 sattelite TV and HBO.  Coffee makers and mini-refrigerators are in every room.
 New Heating & air-conditioning units and free Wi-Fi. 
-<leaflet-map center="35.648349,-118.427896" zoom="13" minzoom="13" maxzoom="15" crossorigin="annonymous" zoomcontrol="" detectretina="">
-<leaflet-marker latitude="35.648349" longitude="-118.427896" open="">
-<div slot="popup">Paradise Cove Lodge</div>
-<img slot="icon" src="/img/adwaita-icons/actions/mark-location.svg" width="32" height="32" decoding="async" loading="lazy" />
-</leaflet-marker>
-</leaflet-map>
+{% include map.html address= site.data.address %}

--- a/contact.html
+++ b/contact.html
@@ -39,11 +39,4 @@ referrer: no-referrer
 		Send
 	</button>
 </form>
-<script type="module" src="https://cdn.kernvalley.us/components/leaflet/map.js" async=""></script>
-<script type="module" src="https://cdn.kernvalley.us/components/leaflet/marker.js" async=""></script>
-<leaflet-map center="35.648349,-118.427896" zoom="13" minzoom="13" maxzoom="15" crossorigin="annonymous" zoomcontrol="" detectretina="">
-	<leaflet-marker latitude="35.648349" longitude="-118.427896" open="">
-		<div slot="popup">Paradise Cove Lodge</div>
-		<img slot="icon" src="/img/adwaita-icons/actions/mark-location.svg" width="32" height="32" decoding="async" loading="lazy" />
-	</leaflet-marker>
-</leaflet-map>
+{% include map.html address= site.data.address %}

--- a/css/header.css
+++ b/css/header.css
@@ -4,6 +4,7 @@
 
 #org-info {
 	background-color: rgba(66, 1, 1, 0.55);
+	color: #e1e1e1;
 	padding: 0.6em;
 	display: inline-block;
 	position: absolute;

--- a/index.html
+++ b/index.html
@@ -23,10 +23,5 @@ referrer: no-referrer
 </section>
 <section>
 	<br />
-	<leaflet-map center="35.648349,-118.427896" zoom="13" minzoom="13" maxzoom="15" crossorigin="annonymous" zoomcontrol="" detectretina="">
-		<leaflet-marker latitude="35.648349" longitude="-118.427896" open="">
-			<div slot="popup">Paradise Cove Lodge</div>
-			<img slot="icon" src="/img/adwaita-icons/actions/mark-location.svg" width="32" height="32" decoding="async" loading="lazy" />
-		</leaflet-marker>
-	</leaflet-map>
+	{% include map.html address= site.data.address %}
 </section>

--- a/location.html
+++ b/location.html
@@ -20,9 +20,4 @@ to Las Vegas, Death Valley, the coast or Sequoia National Forest.</p>
 <p class="inline-block">Stay in one of our comfortable rooms and have dinner with great
 views of the lake and mountains.</p>
 <div class="clearfix"></div>
-<leaflet-map center="35.648349,-118.427896" zoom="13" minzoom="13" maxzoom="15" crossorigin="annonymous" zoomcontrol="" detectretina="">
-	<leaflet-marker latitude="35.648349" longitude="-118.427896" open="">
-		<div slot="popup">Paradise Cove Lodge</div>
-		<img slot="icon" src="/img/adwaita-icons/actions/mark-location.svg" width="32" height="32" decoding="async" loading="lazy" />
-	</leaflet-marker>
-</leaflet-map>
+{% include map.html address= site.data.address %}


### PR DESCRIPTION
- Use fixed text color in header to ensure contrast
- Misc. Leaflet map fixes (accessibility & reusable component)

Resolves #11 