### PR TITLE
Set nav links to inherit color

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
 			<h3>Find us on&hellip;</h3>
 			<div class="social-links">
 				{% for link in site.data.footer.social %}
-					<a href="{{ link.url }}" class="social-link inline-block center" rel="noopener external">
+					<a href="{{ link.url }}" class="social-link inline-block center color-inherit" rel="noopener external">
 						{% include icon.html icon=link.icon class="social-icon" height="48" %}
 						<br />
 						<span class="social-label link-text">{{ link.label }}</span>
@@ -14,25 +14,25 @@
 			<hr />
 		{% endif %}
 		{% if site.data.business.telephone %}
-			<a class="footer-link inline-block" href="tel:{{ site.data.business.telephone }}">
+			<a class="footer-link inline-block color-inherit" href="tel:{{ site.data.business.telephone }}">
 				{% include icon.html icon="call-start" %}
 				<span class="link-text underline">{{ site.data.business.telephone | replace: '+1-', '' }}</span>
 			</a>
 		{% endif %}
 		{% if site.data.business.email %}
-			<a class="footer-link inline-block" href="mailto:{{ site.data.business.email }}">
+			<a class="footer-link inline-block color-inherit" href="mailto:{{ site.data.business.email }}">
 				{% include icon.html icon="mail" %}
 				<span class="link-text underline">{{ site.data.business.email }}</span>
 			</a>
 		{% endif %}
 		{% if site.data.business.address.url %}
-			<a class="footer-link inline-block" href="{{ site.data.business.address.url }}" rel="noopener external">
+			<a class="footer-link inline-block color-inherit" href="{{ site.data.business.address.url }}" rel="noopener external">
 				{% include icon.html icon="map" %}
 				<span class="link-text underline">Directions</span>
 			</a>
 		{% endif %}
 		{% if site.repository %}
-			<a class="footer-link inline-block" href="https://github.com/{{ site.repository.username }}/{{ site.repository.project }}/issues" target="_blank" rel="external noopener">
+			<a class="footer-link inline-block color-inherit" href="https://github.com/{{ site.repository.username }}/{{ site.repository.project }}/issues" target="_blank" rel="external noopener">
 				{% include icon.html icon="issue-opened" %}
 				<span class="link-text underline">Report a Problem</span>
 			</a>
@@ -43,7 +43,7 @@
 		<span>&copy;</span>
 		<time itemprop="copyrightYear">{{ 'now' | date: '%Y' }}</time>
 		<span itemprop="copyrightHolder" itemtype="https://schema.org/{{ site.data.business.type | default: 'LocalBusiness' }}" itemscope="">
-			<a href="{{ site.data.business.url | default: site.url | absolute_url }}" target="_blank" rel="external noopener" itemprop="url">
+			<a href="{{ site.data.business.url | default: site.url | absolute_url }}" target="_blank" rel="external noopener"class="color-inherit" itemprop="url">
 				<span itemprop="name">{{ site.data.business.name }}</span>
 				<meta itemprop="image" content="{{ site.data.business.image }}" />
 				<meta itemprop="logo" content="{{ site.data.business.logo }}" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
 		<meta itemprop="url" content="{{ site.data.business.url | absolute_url | default: site.url }}" />
 		{% include address.html address=site.data.business.address %}
 		{% if site.data.business.telephone %}
-			<a href="tel:{{ site.data.business.telephone }}" itemprop="telephone" content="{{ site.data.business.telephone }}" class="block">
+			<a href="tel:{{ site.data.business.telephone }}" itemprop="telephone" content="{{ site.data.business.telephone }}" class="block color-inherit">
 				{% include icon.html icon="call-start" %}
 				<span>{{ site.data.business.telephone | replace: '+1-', '' }}</span>
 			</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,12 +16,12 @@
 			</a>
 		{% endif %}
 		{% if site.data.business.email %}
-			<a href="mailto:{{ site.data.business.email }}" itemprop="email" content="{{ site.data.email }}" class="block">
+			<a href="mailto:{{ site.data.business.email }}" itemprop="email" content="{{ site.data.email }}" class="color-inherit block">
 				{% include icon.html icon="mail" %}
 				<span>{{ site.data.business.email }}</span>
 			</a>
 		{% endif %}
-		<a href="{{ page.url }}#main" class="block" title="Skip to content">
+		<a href="{{ page.url }}#main" class="block color-inherit" title="Skip to content">
 			<span class="mobile-hidden">Skip to Content</span>
 			<br class="mobile-hidden" />
 			{% include icon.html icon="chevron-down" class="current-color" height="48px" width="64px" %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,7 +1,7 @@
 <nav id="nav" class="sticky top shadow background-accent color-alt z-3 clearfix">
 	<div id="nav-container" class="nav-links">
 		{% for link in site.data.nav %}
-			<a href="{{ link.href }}" class="nav-link flex column{% if page.url == link.href %} current disabled{% endif %}" title="{{ link.label }}">
+			<a href="{{ link.href }}" class="nav-link color-inherit flex column{% if page.url == link.href %} current disabled{% endif %}" title="{{ link.label }}">
 				<span>
 					{% include icon.html icon=link.icon %}
 					<span class="mobile-hidden">{{ link.label }}</span>


### PR DESCRIPTION
These were showing up incorrectly in Edge. I assume it might have something to do with custom properties being set to `inherit`, so set it explicitly.

