### PR TITLE
Fix broken link to location info

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ tags:
 		<h3 class="card-label center">Restaurant</h3>
 		<p class="card-desc">Enjoy Prime Rib, Steaks, and Seafood from our dining room overlooking the Lake.</p>
 	</a>
-	<a href="/location/" class="section-link card shadow color-default center">
+	<a href="/about/#location" class="section-link card shadow color-default center">
 		<img class="card-img fit-cover block" alt="View of the location" class="float-left" src="/img/raster/background/location-350.jpg" width="288" height="188" alt="Paradise Cove Street View" decoding="async" loading="lazy" crossorigin="annonymous" />
 		<h3 class="card-label center">Location</h3>
 		<p class="card-desc">On Highway 178 with great views of Lake Isabella, 3 miles past the Dam on the south side of the lake.</p>


### PR DESCRIPTION
Location page was merged into about page. Link to location section of about page instead.