### PR TITLE
Fix changing dark styles for forced light theme

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -42,7 +42,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	.share-menuitem.btn.btn-outline {
+	:root:not([data-theme="light"]) .share-menuitem.btn.btn-outline {
 		color: #cdcdcd;
 	}
 }


### PR DESCRIPTION
`.btn.btn-outline` is displaying incorrectly.