### PR TITLE
Update nav.css

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -52,3 +52,9 @@ a.disabled {
 		display: none;
 	}
 }
+
+@supports (display: flex) {
+	.nav-link > .nav-item-br {
+		display: none;
+	}
+}


### PR DESCRIPTION
Fix issue in Edge where `<br>`s in flex columns would occupy way too much vertical space.

![image](https://user-images.githubusercontent.com/1627459/116920163-29257000-ac07-11eb-8c87-1b86e55ef2f0.png)
